### PR TITLE
Test for stagecraft `/data-sets` now expects a 403

### DIFF
--- a/features/varnish.feature
+++ b/features/varnish.feature
@@ -70,9 +70,11 @@ Feature: varnish
   # Stagecraft routing
 
   @normal
-  Scenario: I can access Stagecraft data-sets API without a trailing slash
+  Scenario: I can route a request to Stagecraft data-sets API without a trailing slash
     When I GET https://stagecraft.{PP_APP_DOMAIN}/data-sets
-    Then I should receive an HTTP 200
+    Then I should receive an HTTP 403
+    # Requires a secret bearer token - getting a 403 is enough to know we
+    # routed right through to the app.
 
 
   # BUG: see https://www.pivotaltracker.com/story/show/67096896


### PR DESCRIPTION
Since we protected the `/data-sets` endpoint with a token, we should now 
expect to get a 403 rather than a 200 when we hit the `/data-sets` endpoint.

This tells us that we've managed to route through to the app.

See https://www.pivotaltracker.com/story/show/67103208

[#67103208]
