### PR TITLE
Fix test that /data-sets/ redirects to /data-sets

### DIFF
--- a/features/varnish.feature
+++ b/features/varnish.feature
@@ -79,7 +79,7 @@ Feature: varnish
   @normal
   Scenario: I can access Stagecraft data-sets API with a trailing slash
     When I GET https://stagecraft.{PP_APP_DOMAIN}/data-sets/
-    Then I should receive an HTTP 301 redirect to /data-sets
+    Then I should receive an HTTP 301 redirect to https://stagecraft.{PP_APP_DOMAIN}/data-sets
 
   @normal
   Scenario: I can access Stagecraft admin UI with a trailing slash


### PR DESCRIPTION
The feature test needs a full URL, not just the path.
