### PR TITLE
Make Jenkins output a results.json file

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -11,4 +11,4 @@ if [ ! -f .ruby-version ]; then
 fi
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --quiet
-bundle exec rake
+bundle exec cucumber --format json --out ${WORKSPACE}/results.json

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,4 +6,4 @@ echo '> rbenv install $(cat .ruby-version)'
 echo
 
 bundle install
-bundle exec rake
+bundle exec cucumber


### PR DESCRIPTION
We can then use this as a build artifact. Sensu checks can download and parse
this.

Had to change the way we run from `bundle exec rake` to `bundle exec 
cucumber` in order to pass arguments to cucumber.
