### PR TITLE
Allow HTTP PUT to backdrop write API

### DIFF
--- a/features/backdrop_write.feature
+++ b/features/backdrop_write.feature
@@ -28,11 +28,11 @@ Feature: backdrop_write
     Then I should receive an HTTP 401
 
   @normal
-  Scenario: I cannot PUT to backdrop
+  Scenario: I can PUT an empty JSON list to backdrop (empty functionality)
     Given I have the JSON data []
       And I have the HTTP header "Authorization: Bearer qwertyuiop"
-    When I PUT https://www.{PP_APP_DOMAIN}/data/test/test?limit=1
-    Then I should receive an HTTP 405
+    When I PUT https://www.{PP_APP_DOMAIN}/data/test/test
+    Then I should receive an HTTP 200
 
   @normal
   Scenario: I cannot DELETE resources in backdrop


### PR DESCRIPTION
Previously we checked that we _couldn't_ PUT to backdrop write, now we check
that we can, as this is how we empty data sets.
