### PR TITLE
Allow features to be excluded in jenkins

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -11,4 +11,9 @@ if [ ! -f .ruby-version ]; then
 fi
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --quiet
-bundle exec cucumber --format json --out ${WORKSPACE}/results.json
+
+if [ "$PP_EXCLUDE_PATTERN" != "" ]; then
+  EXCLUDE_FEATURE="-e '${PP_EXCLUDE_PATTERN}'"
+fi
+
+bundle exec cucumber --format json --out ${WORKSPACE}/results.json $EXCLUDE_FEATURE


### PR DESCRIPTION
Some features are failing in some environments and fixing them is
outside of our control.

The admin uploader feature is failing in staging and production because
we cannot reach signon.production.alphagov.co.uk.
