### PR TITLE
Mark the admin feature as knownfailing

### DIFF
--- a/features/admin_uploader.feature
+++ b/features/admin_uploader.feature
@@ -1,3 +1,4 @@
+@knownfailing
 Feature: admin_uploader
 
   @normal


### PR DESCRIPTION
In staging and production we cannot reach
signon.production.alphagov.co.uk.

This is most probably a firewall rule from Skyscape.
