### PR TITLE
Use full app domain for stagecraft in production

### DIFF
--- a/features/stagecraft.feature
+++ b/features/stagecraft.feature
@@ -2,27 +2,27 @@ Feature: stagecraft
 
   @normal
   Scenario: I can route a request to Stagecraft data-sets API without a trailing slash
-    When I GET https://stagecraft.{PP_APP_DOMAIN}/data-sets
+    When I GET https://stagecraft.{PP_FULL_APP_DOMAIN}/data-sets
     Then I should receive an HTTP 403
     # Requires a secret bearer token - getting a 403 is enough to know we
     # routed right through to the app.
 
   @normal
   Scenario: I can access Stagecraft data-sets API with a trailing slash
-    When I GET https://stagecraft.{PP_APP_DOMAIN}/data-sets/
-    Then I should receive an HTTP 301 redirect to https://stagecraft.{PP_APP_DOMAIN}/data-sets
+    When I GET https://stagecraft.{PP_FULL_APP_DOMAIN}/data-sets/
+    Then I should receive an HTTP 301 redirect to https://stagecraft.{PP_FULL_APP_DOMAIN}/data-sets
 
   @normal
   Scenario: I can access Stagecraft data-sets API with a trailing slash and query string
-    When I GET https://stagecraft.{PP_APP_DOMAIN}/data-sets/?data-group=aaa
-    Then I should receive an HTTP 301 redirect to https://stagecraft.{PP_APP_DOMAIN}/data-sets?data-group=aaa
+    When I GET https://stagecraft.{PP_FULL_APP_DOMAIN}/data-sets/?data-group=aaa
+    Then I should receive an HTTP 301 redirect to https://stagecraft.{PP_FULL_APP_DOMAIN}/data-sets?data-group=aaa
 
   @normal
   Scenario: I can access Stagecraft admin UI with a trailing slash
-    When I GET https://stagecraft.{PP_APP_DOMAIN}/admin/
+    When I GET https://stagecraft.{PP_FULL_APP_DOMAIN}/admin/
     Then I should receive an HTTP 200
 
   @normal
   Scenario: I can access Stagecraft admin UI without a trailing slash
-    When I GET https://stagecraft.{PP_APP_DOMAIN}/admin
-    Then I should receive an HTTP 301 redirect to https://stagecraft.{PP_APP_DOMAIN}/admin/
+    When I GET https://stagecraft.{PP_FULL_APP_DOMAIN}/admin
+    Then I should receive an HTTP 301 redirect to https://stagecraft.{PP_FULL_APP_DOMAIN}/admin/

--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -6,6 +6,10 @@ def app_domain
   ENV["PP_APP_DOMAIN"] || "preview.performance.service.gov.uk"
 end
 
+def full_app_domain
+  ENV["PP_FULL_APP_DOMAIN"] || ENV["PP_APP_DOMAIN"] || "preview.performance.service.gov.uk"
+end
+
 def govuk_app_domain
   ENV["GOVUK_APP_DOMAIN"] || "preview.alphagov.co.uk"
 end
@@ -25,5 +29,6 @@ end
 
 def replace_env_host(url)
   url.gsub(/{PP_APP_DOMAIN}/, app_domain)
+     .gsub(/{PP_FULL_APP_DOMAIN}/, full_app_domain)
 end
 


### PR DESCRIPTION
Stagecraft is served off
stagecraft.production.performance.service.gov.uk in production rather
than stagecraft.performance.service.gov.uk.
