### PR TITLE
Re-enable admin uploader feature

### DIFF
--- a/features/admin_uploader.feature
+++ b/features/admin_uploader.feature
@@ -1,4 +1,3 @@
-@knownfailing
 Feature: admin_uploader
 
   @normal


### PR DESCRIPTION
This was failing due to an incorrect IP address set for signon in
staging. This has now been fixed.
