### PR TITLE
Skip signon login on staging

### DIFF
--- a/.config/cucumber.yml
+++ b/.config/cucumber.yml
@@ -1,2 +1,3 @@
 ---
 default: --tags ~@knownfailing --tags ~@pending --format pretty
+staging: --tags ~@knownfailing --tags ~@pending --tags ~@not_on_staging --format pretty

--- a/features/admin_uploader.feature
+++ b/features/admin_uploader.feature
@@ -8,6 +8,7 @@ Feature: admin_uploader
     Then the elapsed time should be less than 1 seconds
 
   @normal
+  @not_on_staging
   Scenario: Can log in
     Given the "admin" application has booted
     When I try to login as a valid admin user


### PR DESCRIPTION
Signon-o-tron login does not work on staging because the sigon server
expects to return the request to admin.performance.service.gov.uk which
is production.
