### PR TITLE
Initial draft for spotlight features

### DIFF
--- a/features/spotlight.feature
+++ b/features/spotlight.feature
@@ -1,0 +1,7 @@
+Feature: spotlight
+
+  @normal
+  Scenario: I can access the homepage
+    When I GET https://spotlight.{PP_APP_DOMAIN}/performance
+    Then I should receive an HTTP 200
+      And I should see a strong ETag

--- a/features/step_definitions/http_steps.rb
+++ b/features/step_definitions/http_steps.rb
@@ -24,6 +24,10 @@ Then /^I should receive an HTTP (30[12]) redirect to (.*)$/ do |status, url|
   @response.headers[:location].should == url
 end
 
+Then /^I should see a strong ETag$/ do
+  @response.headers[:etag].should match /"[a-f0-9]{16}"/
+end
+
 
 def headers
   @headers


### PR DESCRIPTION
**do not merge**

In particular, spotlight responses should have an ETag.

Need to upgrade ExpressJS to a version that supports strong ETags first.
