### PR TITLE
Spotlight ETags are base64-encoded

### DIFF
--- a/features/spotlight.feature
+++ b/features/spotlight.feature
@@ -1,6 +1,6 @@
 Feature: spotlight
 
-  @normal, @knownfailing
+  @normal
   Scenario: I can access the homepage
     When I GET https://spotlight.{PP_APP_DOMAIN}/performance
     Then I should receive an HTTP 200

--- a/features/step_definitions/http_steps.rb
+++ b/features/step_definitions/http_steps.rb
@@ -25,7 +25,7 @@ Then /^I should receive an HTTP (30[12]) redirect to (.*)$/ do |status, url|
 end
 
 Then /^I should see a strong ETag$/ do
-  @response.headers[:etag].should match /"[a-f0-9]{16}"/
+  @response.headers[:etag].should match /"[A-Za-z0-9\+\/]{22,24}[=]{0,2}"/
 end
 
 


### PR DESCRIPTION
See
https://github.com/visionmedia/express/blob/db4448dda88f23dccb6f4f6f19481dda0b39e31a/lib/utils.js#L59
