### PR TITLE
Use full app domain for Spotlight

### DIFF
--- a/features/spotlight.feature
+++ b/features/spotlight.feature
@@ -2,6 +2,6 @@ Feature: spotlight
 
   @normal
   Scenario: I can access the homepage
-    When I GET https://spotlight.{PP_APP_DOMAIN}/performance
+    When I GET https://spotlight.{PP_FULL_APP_DOMAIN}/performance
     Then I should receive an HTTP 200
       And I should see a strong ETag


### PR DESCRIPTION
It's hosted at spotlight.production.service.etc
