### PR TITLE
Disable sign-on-o-tron tests on staging

### DIFF
--- a/features/admin_app.feature
+++ b/features/admin_app.feature
@@ -1,6 +1,7 @@
 Feature: admin app
 
   @normal
+  @not_on_staging
   Scenario: Quickly being redirected to Sign-on-o-tron
     Given I am benchmarking
     When I GET https://admin-beta.{PP_APP_DOMAIN}/login
@@ -8,6 +9,7 @@ Feature: admin app
     And the elapsed time should be less than 1 second
 
   @normal
+  @not_on_staging
   Scenario: Can log in to the admin app using Sign-on-o-tron
     When I try to login to Signon from https://admin-beta.{PP_APP_DOMAIN}/login
     Then I should be on a page with a URL that begins https://admin-beta.{PP_APP_DOMAIN}/auth/gds/callback


### PR DESCRIPTION
Sign-on-o-tron wont work in staging due to the way dns is setup. This
change brings things into line with the other sign-on-o-tron test which
is also skipped on staging.
