### PR TITLE
Update admin app redirect from Signon

### DIFF
--- a/features/admin_app.feature
+++ b/features/admin_app.feature
@@ -12,4 +12,4 @@ Feature: admin app
   @not_on_staging
   Scenario: Can log in to the admin app using Sign-on-o-tron
     When I try to login to Signon from https://admin-beta.{PP_APP_DOMAIN}/login
-    Then I should be on a page with a URL that begins https://admin-beta.{PP_APP_DOMAIN}/auth/gds/callback
+    Then I should be on a page with a URL that begins https://admin-beta.{PP_APP_DOMAIN}/


### PR DESCRIPTION
The admin app will now redirect the user to the application root, so this smoke test is incorrect.
