### PR TITLE
List data sets

### DIFF
--- a/features/admin_app.feature
+++ b/features/admin_app.feature
@@ -13,3 +13,9 @@ Feature: admin app
   Scenario: Can log in to the admin app using Sign-on-o-tron
     When I try to login to Signon from https://admin-beta.{PP_APP_DOMAIN}/login
     Then I should be on a page with a URL that begins https://admin-beta.{PP_APP_DOMAIN}/
+
+  @normal
+  @not_on_staging
+  Scenario: Can see a list of data sets
+    When I try to login to Signon from https://admin-beta.{PP_APP_DOMAIN}/login
+    Then I should see a list of data sets containing test

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -24,3 +24,7 @@ Then /^I should be on the admin post-login page$/ do
   page.has_text?("Signed in as ").should eq(true), page.text #page has "Signed in as X" message
   page.has_text?("Sign out").should eq(true), page.text # page has a logout link
 end
+
+Then /^I should see a list of data sets containing (.*)$/ do |data_set_name|
+  page.find(:css, ".data-set-list > li > .data-set-name").text.should == data_set_name
+end


### PR DESCRIPTION
This now works on preview if the jenkins job is set to run the branch. For it to work in other environments, the user must be given access to the app in signon and to the dataset 'test' in the stagecraft of that environment.

One question though - should we aim for more descriptive html as the css selector in Rob's commit requires, or is the fixed selector okay (it doesn't require changes to the admin app but maybe the admin app html should be more descriptive?)
