### PR TITLE
Expect a 401 for unauthorised stagecraft access

### DIFF
--- a/features/stagecraft.feature
+++ b/features/stagecraft.feature
@@ -3,8 +3,8 @@ Feature: stagecraft
   @normal
   Scenario: I can route a request to Stagecraft data-sets API without a trailing slash
     When I GET https://stagecraft.{PP_FULL_APP_DOMAIN}/data-sets
-    Then I should receive an HTTP 403
-    # Requires a secret bearer token - getting a 403 is enough to know we
+    Then I should receive an HTTP 401
+    # Requires a secret bearer token - getting a 401 is enough to know we
     # routed right through to the app.
 
   @normal


### PR DESCRIPTION
This has changed in stagecraft so that we can distinguish between
unauthorised and forbidden.
