### PR TITLE
.data-set-type is no longer a direct descendant

### DIFF
--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -26,5 +26,5 @@ Then /^I should be on the admin post-login page$/ do
 end
 
 Then /^I should see a list of (.*) data sets containing (.*) data type$/ do |data_set_group_name, data_set_type_name|
-  page.find(:css, "li[data-name='#{data_set_group_name}'] > ul.data-set-list > li > .data-set-type").text.should == data_set_type_name
+  page.find(:css, "li[data-name='#{data_set_group_name}'] > ul.data-set-list > li .data-set-type").text.should == data_set_type_name
 end


### PR DESCRIPTION
Now this lives in the fallback element it is no longer a direct
descendant of the li, it should still only match one element per li.
