### PR TITLE
Add a realy simple smoke test for staging

### DIFF
--- a/features/admin_app.feature
+++ b/features/admin_app.feature
@@ -1,5 +1,9 @@
 Feature: admin app
 
+  Scenario: Admin app is up on staging
+    When I GET https://admin-beta.{PP_APP_DOMAIN}/
+    Then I should receive an HTTP 302
+
   @normal
   @not_on_staging
   Scenario: Quickly being redirected to Sign-on-o-tron


### PR DESCRIPTION
The sensu script is failing because no scenarios are run on staging -
quickest way to fix this is to add a really simple smoke test so it can
pick up that a scenario has run.
