### PR TITLE
Remove limit parameter from write API requests

### DIFF
--- a/features/backdrop_write.feature
+++ b/features/backdrop_write.feature
@@ -17,14 +17,14 @@ Feature: backdrop_write
   @normal
   Scenario: I cannot write to Backdrop without an Authorization header
     Given I have the JSON data []
-    When I POST https://www.{PP_APP_DOMAIN}/data/test/test?limit=1
+    When I POST https://www.{PP_APP_DOMAIN}/data/test/test
     Then I should receive an HTTP 401
 
   @normal
   Scenario: I cannot write to Backdrop using an inappropriate Authorization header
     Given I have the JSON data []
       And I have the HTTP header "Authorization: some-other-thing"
-    When I POST https://www.{PP_APP_DOMAIN}/data/test/test?limit=1
+    When I POST https://www.{PP_APP_DOMAIN}/data/test/test
     Then I should receive an HTTP 401
 
   @normal
@@ -37,5 +37,5 @@ Feature: backdrop_write
   @normal
   Scenario: I cannot DELETE resources in backdrop
     Given I have the HTTP header "Authorization: Bearer qwertyuiop"
-    When I DELETE https://www.{PP_APP_DOMAIN}/data/test/test?limit=1
+    When I DELETE https://www.{PP_APP_DOMAIN}/data/test/test
     Then I should receive an HTTP 405


### PR DESCRIPTION
As far as I know these requests don't make use of the limit parameter, so having it here is confusing.
