### PR TITLE
Rename admin app staging check

### DIFF
--- a/features/admin_app.feature
+++ b/features/admin_app.feature
@@ -1,6 +1,6 @@
 Feature: admin app
 
-  Scenario: Admin app is up on staging
+  Scenario: Admin app is up
     When I GET https://admin-beta.{PP_APP_DOMAIN}/
     Then I should receive an HTTP 302
 


### PR DESCRIPTION
Even though this check is named 'staging' because it's the only check in this file that runs on staging, it can still alert in other environments which provides confusing alert titles.
