### PR TITLE
Check that response times are not horrendous

### DIFF
--- a/features/spotlight.feature
+++ b/features/spotlight.feature
@@ -2,6 +2,8 @@ Feature: spotlight
 
   @normal
   Scenario: I can access the homepage
+    Given I am benchmarking
     When I GET https://spotlight.{PP_FULL_APP_DOMAIN}/performance
     Then I should receive an HTTP 200
       And I should see a strong ETag
+      And the elapsed time should be less than 2 second


### PR DESCRIPTION
Ideally it would be less than 1 second, but being lenient for now. Once
we have a webpagetest instance polling this, we’ll have more confidence
in bringing this down.
