### PR TITLE
Add test that image fallbacks are correctly sized

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "capybara", "2.1.0"
 gem "capybara-mechanize", "1.1.0"
+gem "chunky_png", "1.3.3"
 gem "cucumber", "1.3.10"
 gem "nokogiri", "1.6.1"
 gem "rake", "10.1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     capybara-mechanize (1.1.0)
       capybara (~> 2.1.0)
       mechanize (~> 2.7)
+    chunky_png (1.3.3)
     cucumber (1.3.10)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -69,6 +70,7 @@ PLATFORMS
 DEPENDENCIES
   capybara (= 2.1.0)
   capybara-mechanize (= 1.1.0)
+  chunky_png (= 1.3.3)
   cucumber (= 1.3.10)
   nokogiri (= 1.6.1)
   rake (= 10.1.1)

--- a/features/images.feature
+++ b/features/images.feature
@@ -1,0 +1,8 @@
+Feature: image fallbacks
+
+  @normal
+  Scenario: Image fallbacks look vaguely correct
+    When I GET https://spotlight.{PP_FULL_APP_DOMAIN}/performance/carers-allowance/volumetrics.png
+    Then I should receive an HTTP 200
+     And the image should be between 950 and 970 pixels wide
+     And the image should be between 400 and 410 pixels high

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -1,0 +1,13 @@
+require 'chunky_png'
+
+Then /^the image should be between (\d+) and (\d+) pixels wide$/ do |lower_bound, upper_bound|
+  image = ChunkyPNG::Image.from_blob(@response)
+  image.width.should > lower_bound.to_i
+  image.width.should < upper_bound.to_i
+end
+
+Then /^the image should be between (\d+) and (\d+) pixels high$/ do |lower_bound, upper_bound|
+  image = ChunkyPNG::Image.from_blob(@response)
+  image.height.should > lower_bound.to_i
+  image.height.should < upper_bound.to_i
+end


### PR DESCRIPTION
On a scale from 1 to “_what did you just do?_”, how ridiculous is this?

---

We had a bug last week that the image fallbacks we had been serving were unstyled because of PhantomJS's inability to connect to our assets host using SSLv3.

This bug was present in production for almost a month and nobody noticed because we have no automated testing of our images.

This commit introduces a very rough check for our image fallbacks. It asserts that a particular image is approximately a certain size. I expect this would only catch the most obvious breakages, but it's better than nothing.
