### PR TITLE
Add 4 second limit to image fallback requests

### DIFF
--- a/features/images.feature
+++ b/features/images.feature
@@ -2,7 +2,9 @@ Feature: image fallbacks
 
   @normal
   Scenario: Image fallbacks look vaguely correct
+    Given I am benchmarking
     When I GET https://spotlight.{PP_FULL_APP_DOMAIN}/performance/carers-allowance/volumetrics.png
     Then I should receive an HTTP 200
+     And the elapsed time should be less than 4 seconds
      And the image should be between 950 and 970 pixels wide
      And the image should be between 400 and 410 pixels high


### PR DESCRIPTION
4 seconds is a bit of a guess, based on the fact that I don't think we should be overly concerned if these requests are slow.
