### PR TITLE
Paths no longer need to redirect with resource view.

### DIFF
--- a/features/stagecraft.feature
+++ b/features/stagecraft.feature
@@ -8,16 +8,6 @@ Feature: stagecraft
     # routed right through to the app.
 
   @normal
-  Scenario: I can access Stagecraft data-sets API with a trailing slash
-    When I GET https://stagecraft.{PP_FULL_APP_DOMAIN}/data-sets/
-    Then I should receive an HTTP 301 redirect to https://stagecraft.{PP_FULL_APP_DOMAIN}/data-sets
-
-  @normal
-  Scenario: I can access Stagecraft data-sets API with a trailing slash and query string
-    When I GET https://stagecraft.{PP_FULL_APP_DOMAIN}/data-sets/?data-group=aaa
-    Then I should receive an HTTP 301 redirect to https://stagecraft.{PP_FULL_APP_DOMAIN}/data-sets?data-group=aaa
-
-  @normal
   Scenario: I can access Stagecraft admin UI with a trailing slash
     When I GET https://stagecraft.{PP_FULL_APP_DOMAIN}/admin/
     Then I should receive an HTTP 200


### PR DESCRIPTION
After migrating data_sets to resource view in stagecraft, these routes
no longer need to redirect - they are valid and return a 401 when they
are not authorized.