### PR TITLE
The administer dashboards link text has changed

### DIFF
--- a/features/admin_app.feature
+++ b/features/admin_app.feature
@@ -35,5 +35,5 @@ Feature: admin app
   @not_on_staging
   Scenario: Can see the dashboard administration page
     When I try to login to Signon from https://admin-beta.{PP_APP_DOMAIN}/
-    And I follow the "Administer dashboards" link
+    And I follow the Administer dashboards link
     Then I should be on the dashboard administration page

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -42,6 +42,10 @@ When /^I follow the "(.*)" link$/ do |link_text|
   click_link link_text 
 end
 
+When /^I follow the Administer dashboards link$/ do
+  page.find(:css, "[href='/administer-dashboards']").click
+end
+
 Then /^I should be on the dashboard administration page$/ do
   h1 = page.find(:css, "h1")
   h1.text.should == "Administer dashboards"


### PR DESCRIPTION
It may change again in future or change back. We should be agnostic
about the text and use a selector. A class or id would be better but
this should work for now and it's debateable whether we should be adding
in classes or ids just for test purposes without agreeing on a
convention.

This passes on preview