### PR TITLE
Fix selector datasets list after perms change

### DIFF
--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -16,7 +16,7 @@ When /^I upload (.*) to the (.*) data type in the (.*) data group/ do |path, dat
 end
 
 Then /^I should see a list of (.*) data sets containing (.*) data type$/ do |data_set_group_name, data_set_type_name|
-  page.find(:css, "li[data-name='#{data_set_group_name}'] > ul.data-set-list > li .data-set-type").text.should == data_set_type_name
+  page.find(:css, "li[data-name='#{data_set_group_name}'] > ul.data-set-list > li:first-child .data-set-type").text.should == data_set_type_name
 end
 
 Then /^I should see a success message for the (.*) data type in the (.*) data group/ do |data_type, data_group|


### PR DESCRIPTION
Due to the new feature in the admin app that allows users to select
datasets from a dropdown list, we have given access to all datasets to
users with the dashboard-editor permission, which the smokey user has.
This causes the test to fail because there are 2 datasets with a
datagroup of test, and the selector is ambiguous because it matches 2
elements. By switching to first-child, we will only match one element.

This will still fail if another dataset is added with a datagroup of
test that is listed before test, but I think this fix is good enough for
now.