### PR TITLE
Update smokey tests to use the new dashboards url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ Use the provided script:
 ./run_tests.sh
 ```
 
+### In development:
+
+1. Deploy the branch you want to test to preview.
+2. Used the provided script:
+
+```bash
+SIGNON_USERNAME=See manual for signon credentials SIGNON_PASSWORD=See manual for signon credentials ./run_tests.sh
+```
+
+
 ## Environment
 
 By default these tests run against the Performance Platform's preview environment.

--- a/features/admin_app.feature
+++ b/features/admin_app.feature
@@ -35,5 +35,5 @@ Feature: admin app
   @not_on_staging
   Scenario: Can see the dashboard administration page
     When I try to login to Signon from https://admin-beta.{PP_APP_DOMAIN}/
-    And I follow the Administer dashboards link
+    And I follow the Your dashboards link
     Then I should be on the dashboard administration page

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -27,11 +27,11 @@ When /^I follow the "(.*)" link$/ do |link_text|
   click_link link_text 
 end
 
-When /^I follow the Administer dashboards link$/ do
-  page.find(:css, "[href='/admin/dashboards']").click
+When /^I follow the Your dashboards link$/ do
+  page.find(:css, "[href='/dashboards']").click
 end
 
 Then /^I should be on the dashboard administration page$/ do
   h1 = page.find(:css, "h1")
-  h1.text.should == "Administer dashboards"
+  h1.text.should == "Your dashboards"
 end


### PR DESCRIPTION
Updated URLs in Admin app feature to  use the new dashboard controller.

See: https://github.com/alphagov/performanceplatform-admin/pull/96