### PR TITLE
Bump time to wait for homepage to load

### DIFF
--- a/features/spotlight.feature
+++ b/features/spotlight.feature
@@ -6,4 +6,4 @@ Feature: spotlight
     When I GET https://spotlight.{PP_FULL_APP_DOMAIN}/performance
     Then I should receive an HTTP 200
       And I should see a strong ETag
-      And the elapsed time should be less than 2 second
+      And the elapsed time should be less than 6 second


### PR DESCRIPTION
2 seconds is causing this to fail all the time on production. We have
decided not to focus on improving spotlight performance, so we should
not alert at 2 seconds. Looking at request times, even six seconds is
likely to result in failures, but this should reduce the amount of
failures seen.