### PR TITLE
Remove trailing slash test

### DIFF
--- a/features/backdrop_write.feature
+++ b/features/backdrop_write.feature
@@ -8,13 +8,6 @@ Feature: backdrop_write
     Then I should receive an HTTP 200
 
   @normal
-  Scenario: I cannot write to Backdrop if I use a trailing slash
-    Given I have the JSON data []
-      And I have the HTTP header "Authorization: Bearer qwertyuiop"
-    When I POST https://www.{PP_APP_DOMAIN}/data/test/test/
-    Then I should receive an HTTP 404
-
-  @normal
   Scenario: I cannot write to Backdrop without an Authorization header
     Given I have the JSON data []
     When I POST https://www.{PP_APP_DOMAIN}/data/test/test


### PR DESCRIPTION
On the gov.uk infrastructure, post requests with a trailing slash are
redirected with a 301 status so this test fails.

Browsers and clients given a 301 status to a post will make a GET
request to the location given in the 301 response, which could be an
issue if there is a particularly large dataset, or if the client
interprets that response as a succesful post, which has not happened.

It is possible that a 307 status is the correct status to respond with,
which causes the browser / client to reissue the request with the same
method.

This was originally added to test the logic in
https://github.com/alphagov/pp-puppet/pull/267 was correct.

Querying kibana for post requests made with a trailing slash at the
nginx level, before it hits varnish where this change was made showed
no requests with a trailing slash in the last 30 days

Query used was

@tags:nginx AND @fields.http_host:"www.performance.service.gov.uk" AND
@fields.request_method:"POST" AND @fields.status:404

Given the fact there are no requests made with this behaviour, and
overriding the post behaviour would affect the whole of gov.uk, and the
likely impact if a client does try and post to a url with a trailing
slash is minimal, we have decided to remove the test.