### PR TITLE
Change spotlight to use GOVUK_APP_DOMAIN

### DIFF
--- a/features/images.feature
+++ b/features/images.feature
@@ -3,7 +3,7 @@ Feature: image fallbacks
   @normal
   Scenario: Image fallbacks look vaguely correct
     Given I am benchmarking
-    When I GET https://spotlight.{PP_FULL_APP_DOMAIN}/performance/carers-allowance/volumetrics.png
+    When I GET https://spotlight.{GOVUK_APP_DOMAIN}/performance/carers-allowance/volumetrics.png
     Then I should receive an HTTP 200
      And the elapsed time should be less than 4 seconds
      And the image should be between 950 and 970 pixels wide

--- a/features/spotlight.feature
+++ b/features/spotlight.feature
@@ -3,7 +3,7 @@ Feature: spotlight
   @normal
   Scenario: I can access the homepage
     Given I am benchmarking
-    When I GET https://spotlight.{PP_FULL_APP_DOMAIN}/performance
+    When I GET https://spotlight.{GOVUK_APP_DOMAIN}/performance
     Then I should receive an HTTP 200
       And I should see a strong ETag
       And the elapsed time should be less than 6 second


### PR DESCRIPTION
Spotlight is being moved to GOV.UK infrastructure, so we should use the hostname that GOV.UK assigns to it.

Please don't merge this pull request yet - merging it before the move will cause the existing smoke tests to start failing. I'm just opening it now so that it doesn't get forgotten about.