### PR TITLE
Remove test for unsupported functionality

### DIFF
--- a/features/backdrop_read.feature
+++ b/features/backdrop_read.feature
@@ -5,12 +5,6 @@ Feature: backdrop_read
     When I GET https://www.{PP_APP_DOMAIN}/data/test/test?limit=1
     Then I should receive an HTTP 200
 
-  @normal
-  Scenario: I can access Backdrop with a trailing slash
-    When I GET https://www.{PP_APP_DOMAIN}/data/test/test/
-    Then I should receive an HTTP 301 redirect to /data/test/test
-
-
   # BUG: see https://www.pivotaltracker.com/story/show/67097376
   @normal, @knownfailing
   Scenario: I can access Backdrop with a trailing slash and query parameters


### PR DESCRIPTION
We no longer support this redirect in the new infrastructure. It hasn't
been a problem so far. Remove the test.